### PR TITLE
CommandBar/Flyout/TreeView refactor

### DIFF
--- a/PassKeep.App/App.xaml
+++ b/PassKeep.App/App.xaml
@@ -22,6 +22,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
             </ResourceDictionary.ThemeDictionaries>
             
             <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls"/>
                 <ResourceDictionary Source="ResourceDictionaries/AppThemeDictionary.xaml" />
                 <rd:DataTemplateDictionary />
             </ResourceDictionary.MergedDictionaries>
@@ -58,6 +59,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
             <convert:ObjectToStringConverter x:Key="ObjectToStringConverter" />
 
             <dts:FullNodeTemplateSelector x:Key="NodeTemplateSelector" />
+            <dts:TreeNodeTemplateSelector x:Key="TreeNodeTemplateSelector" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/PassKeep.App/DataTemplateSelectors/NodeTemplateSelector.cs
+++ b/PassKeep.App/DataTemplateSelectors/NodeTemplateSelector.cs
@@ -2,12 +2,11 @@
 // This file is part of PassKeep and is licensed under the GNU GPL v3.
 // For the full license, see gpl-3.0.md in this solution or under https://bitbucket.org/sapph/passkeep/src
 
-using PassKeep.Lib.Contracts.Models;
 using PassKeep.Lib.Contracts.ViewModels;
 using System;
-using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using MUXC = Microsoft.UI.Xaml.Controls;
 
 namespace PassKeep.DataTemplateSelectors
 {
@@ -23,8 +22,7 @@ namespace PassKeep.DataTemplateSelectors
 
         protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
         {
-            FrameworkElement element = container as FrameworkElement;
-            if (element == null)
+            if (container != null && !(container is FrameworkElement element))
             {
                 return null;
             }
@@ -36,14 +34,12 @@ namespace PassKeep.DataTemplateSelectors
                 String.Format("{0}{1}", NodeTemplateSelector.EntryPrefix, Suffix)
             ];
 
-            IDatabaseNodeViewModel node = item as IDatabaseNodeViewModel;
-            if (node == null)
+            if (!(item is IDatabaseNodeViewModel node))
             {
                 return null;
             }
 
-            IDatabaseEntryViewModel entry = node as IDatabaseEntryViewModel;
-            if (entry == null)
+            if (!(node is IDatabaseEntryViewModel entry))
             {
                 // Group only
                 return groupTemplate;
@@ -75,6 +71,34 @@ namespace PassKeep.DataTemplateSelectors
         protected override string Suffix
         {
             get { return "_Snapped"; }
+        }
+    }
+
+    /// <summary>
+    /// The NodeTemplateSelector to use for TreeViews.
+    /// </summary>
+    public class TreeNodeTemplateSelector : NodeTemplateSelector
+    {
+        protected override string Suffix
+        {
+            get { return "_Tree"; }
+        }
+
+        protected override DataTemplate SelectTemplateCore(object item)
+        {
+            return base.SelectTemplateCore(item, null);
+            // return (DataTemplate)Application.Current.Resources["GroupTemplate_Tree"];
+        }
+
+        protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+        {
+            if (item is MUXC.TreeViewNode node)
+            {
+                item = node.Content;
+            }
+
+            // return (DataTemplate)Application.Current.Resources["GroupTemplate_Tree"];
+            return base.SelectTemplateCore(item, container);
         }
     }
 }

--- a/PassKeep.App/Framework/ContainerBootstrapper.cs
+++ b/PassKeep.App/Framework/ContainerBootstrapper.cs
@@ -139,7 +139,11 @@ namespace PassKeep.Framework
                 .RegisterType<IDatabaseCredentialProviderFactory, DatabaseCredentialProviderFactory>(new ContainerControlledLifetimeManager())
                 .RegisterType<ISavedCredentialsViewModelFactory, SavedCredentialViewModelFactory>(new ContainerControlledLifetimeManager())
                 .RegisterType<IDatabaseSettingsViewModelFactory, DatabaseSettingsViewModelFactory>(new ContainerControlledLifetimeManager())
-                .RegisterType<IDatabaseCandidateFactory, StorageFileDatabaseCandidateFactory>(new ContainerControlledLifetimeManager());
+                .RegisterType<IDatabaseCandidateFactory, StorageFileDatabaseCandidateFactory>(new ContainerControlledLifetimeManager())
+                .RegisterType<IDatabasePersistenceServiceFactory, DefaultFilePersistenceServiceFactory>(new ContainerControlledLifetimeManager());
+            
+            // Reuse this type
+            container.RegisterType<IDatabasePersistenceStatusProvider>(new InjectionFactory(c => c.Resolve<DefaultFilePersistenceServiceFactory>()));
 
             // KeePass
             container.RegisterType<IKdbxReader, KdbxReader>();

--- a/PassKeep.App/Framework/RootView.xaml
+++ b/PassKeep.App/Framework/RootView.xaml
@@ -9,293 +9,140 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
     x:Class="PassKeep.Framework.RootView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:fw="using:PassKeep.Framework"
     xmlns:vb="using:PassKeep.ViewBases"
-    xmlns:local="using:PassKeep.Framework"
-    xmlns:flyouts="using:PassKeep.Views.Flyouts"
+    xmlns:vm="using:PassKeep.Lib.Contracts.ViewModels"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <vb:RootViewBase.Resources>
-        <Style x:Key="SplitViewButton" TargetType="Button">
-            <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}"/>
-            <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
-            <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundTransparentBrush}"/>
-            <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}"/>
-            <Setter Property="Padding" Value="0"/>
-            <Setter Property="HorizontalAlignment" Value="Left"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
-            <Setter Property="FontWeight" Value="Normal"/>
-            <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
-            <Setter Property="UseSystemFocusVisuals" Value="True"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
-                            <VisualStateManager.VisualStateGroups>
-                                <VisualStateGroup x:Name="CommonStates">
-                                    <VisualState x:Name="Normal" />
-                                    <VisualState x:Name="PointerOver" />
-                                    <VisualState x:Name="Pressed">
-                                        <Storyboard>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background" Storyboard.TargetName="RootGrid">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlBackgroundBaseMediumLowBrush}"/>
-                                            </ObjectAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground" Storyboard.TargetName="ContentPresenter">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightBaseHighBrush}"/>
-                                            </ObjectAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                    </VisualState>
-                                </VisualStateGroup>
-                            </VisualStateManager.VisualStateGroups>
-                            <ContentPresenter x:Name="ContentPresenter" AutomationProperties.AccessibilityView="Raw" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTransitions="{TemplateBinding ContentTransitions}" Content="{TemplateBinding Content}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Padding="0" Margin="8,4,8,4"/>
-                        </Grid>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-        
-        <Style x:Key="SplitViewGlyph" TargetType="FontIcon">
-            <Setter Property="Width" Value="48" />
-            <Setter Property="FontFamily" Value="Segoe MDL2 Assets" />
-            <Setter Property="FontSize" Value="20" />
-        </Style>
-    </vb:RootViewBase.Resources>
-
-    <RelativePanel Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                <!-- "Mobile" compressed view -->
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="mainSplitView.DisplayMode" Value="Overlay" />
-                        <Setter Target="mainSplitView.IsPaneOpen" Value="False" />
-                    </VisualState.Setters>
-                </VisualState>
-
-                <!-- "Main" view with compact flyout -->
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="720" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="mainSplitView.DisplayMode" Value="CompactInline" />
-                        <Setter Target="mainSplitView.IsPaneOpen" Value="False" />
-                    </VisualState.Setters>
-                </VisualState>
-
-                <!-- "Wide" view with open pane -->
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="1000" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="mainSplitView.DisplayMode" Value="CompactInline" />
-                        <Setter Target="mainSplitView.IsPaneOpen" Value="True" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-
-        <!-- "Chrome" -->
-        <RelativePanel x:Name="appChrome" Background="{ThemeResource AppBarBackgroundThemeBrush}"
-                       RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True">
-            <!-- Hamburger/Title bar-->
-            <Button x:Name="splitViewButton" Click="SplitViewToggle_Click"
-                    Width="48"
-                    Background="Transparent"
-                    Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
-                    Padding="12" Margin="0" Style="{StaticResource SplitViewButton}">
-                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE700;" FontSize="20" />
-            </Button>
-            
-            <!-- Clipboard clear timer -->
-            <RelativePanel Height="30" RelativePanel.LeftOf="savingIndicator" RelativePanel.AlignVerticalCenterWithPanel="True"
-                           Margin="0,0,10,0"
-                           Visibility="{x:Bind ViewModel.ClipboardClearViewModel.TimeRemainingInSeconds, Mode=OneWay, Converter={StaticResource NonZeroDoubleToVisibilityConverter}}">
-                <TextBlock x:Name="clipboardClearIcon" FontFamily="Segoe MDL2 Assets" Text="&#xE16D;" FontSize="20"
-                           RelativePanel.AlignRightWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True" />
-                <Border x:Name="clipboardClearTimerText" BorderBrush="{x:Null}"
-                        RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignBottomWithPanel="True"
-                        RelativePanel.LeftOf="clipboardClearIcon">
-                    <TextBlock x:Name="clipboardClearTimer" FontSize="20"
-                               Text="{x:Bind ViewModel.ClipboardClearViewModel.TimeRemainingInSeconds, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.0}'}"/>
-                </Border>
-            </RelativePanel>
-
-            <!-- Saving progress indicator -->
-            <RelativePanel x:Name="savingIndicator" x:Uid="SavingIndicator" Height="30" Margin="0,0,10,0" Visibility="Collapsed"
-                           RelativePanel.AlignRightWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True">
-                <ProgressRing x:Name="savingIndicatorRing" Height="30" Width="30" Foreground="{ThemeResource AppBarItemForegroundThemeBrush}" IsActive="True"
-                              RelativePanel.AlignHorizontalCenterWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True" />
-                <FontIcon FontSize="12" Foreground="{ThemeResource AppBarItemForegroundThemeBrush}" FontFamily="Segoe MDL2 Assets"
-                          Glyph="&#xE105;" RelativePanel.AlignHorizontalCenterWith="savingIndicatorRing" RelativePanel.AlignVerticalCenterWith="savingIndicatorRing" />
-            </RelativePanel>
-            
-            <!-- Back button -->
-            <!-- Removed in favor of system chrome -->
-            <!--
-            <Button  x:Name="backButton" Command="{x:Bind ContentBackCommand, Mode=OneWay}"
-                     RelativePanel.RightOf="splitViewButton" RelativePanel.AlignVerticalCenterWith="splitViewButton"
-                     Style="{ThemeResource NavigationBackButtonNormalStyle}"
-                     VerticalAlignment="Top"
-                     AutomationProperties.Name="Back"
-                     AutomationProperties.AutomationId="BackButton"
-                     AutomationProperties.ItemType="Navigation Button"/>
-
-            <TextBlock x:Uid="AppName" Text="Placeholder"
-                       Margin="5" Style="{ThemeResource BodyTextBlockStyle}"
-                       RelativePanel.RightOf="backButton" RelativePanel.AlignVerticalCenterWith="backButton" />
-            -->
-        </RelativePanel>
-
+    <Grid>
         <!-- Main content -->
-        <SplitView x:Name="mainSplitView"
-                   CompactPaneLength="48" OpenPaneLength="200"
-                   RelativePanel.Below="appChrome"
-                   RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
-                   RelativePanel.AlignBottomWithPanel="True">
-            <SplitView.Pane>
-                <ListView x:Name="splitViewList" HorizontalAlignment="Stretch"
-                          SelectionMode="Single" SelectionChanged="SplitViewList_SelectionChanged">
+        <muxc:NavigationView x:Name="NavigationView"
+            CompactModeThresholdWidth="0" ExpandedModeThresholdWidth="1007"
+            IsSettingsVisible="True"
+            ItemInvoked="NavigationView_ItemInvoked"
+            SelectionChanged="NavigationView_SelectionChanged"
+            BackRequested="NavigationView_BackRequested">
+            <muxc:NavigationView.MenuItems>
+                <muxc:NavigationViewItem x:Uid="DashboardNav" Content="DashboardPlaceholder" x:Name="dashNavItem">
+                    <muxc:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE12A;" />
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
 
-                    <ListView.Resources>
-                        <Style TargetType="ListViewItem">
-                            <Setter Property="MinWidth" Value="0" />
-                            <Setter Property="Padding" Value="0" />
-                        </Style>
-                    </ListView.Resources>
-                    
-                    <!-- ListViewItems consisting of:
-                            * Glyph
-                            * TextBlocks to the right -->
-                    <ListViewItem x:Name="dashItem" IsSelected="True">
-                        <RelativePanel>
-                            <FontIcon x:Name="dashGlyph" Style="{StaticResource SplitViewGlyph}" Glyph="&#xE12A;"></FontIcon>
-                            <TextBlock x:Uid="Dashboard" RelativePanel.RightOf="dashGlyph" RelativePanel.AlignVerticalCenterWith="dashGlyph"
-                                       Visibility="{x:Bind mainSplitView.IsPaneOpen, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">Dash placeholder</TextBlock>
-                        </RelativePanel>
-                    </ListViewItem>
-                    
-                    <ListViewItem x:Name="openItem">
-                        <RelativePanel>
-                            <FontIcon x:Name="openGlyph" Style="{StaticResource SplitViewGlyph}" Glyph="&#xE1A5;"></FontIcon>
-                            <TextBlock x:Uid="OpenDatabaseLabel" RelativePanel.RightOf="openGlyph" RelativePanel.AlignVerticalCenterWith="openGlyph"
-                                       Visibility="{x:Bind mainSplitView.IsPaneOpen, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">Open placeholder</TextBlock>
-                        </RelativePanel>
-                    </ListViewItem>
+                <muxc:NavigationViewItem x:Uid="OpenNav" Content="OpenPlaceholder" x:Name="openNavItem">
+                    <muxc:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE1A5;" />
+                    </muxc:NavigationViewItem.Icon>
+                    <muxc:NavigationViewItem.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="O" Modifiers="Control" />
+                    </muxc:NavigationViewItem.KeyboardAccelerators>
+                </muxc:NavigationViewItem>
 
-                    <ListViewItem x:Name="dbHomeItem"
-                                  Visibility="{x:Bind ViewModel.DecryptedDatabase, Converter={StaticResource ExistenceToVisibilityConverter}, Mode=OneWay}">
-                        <RelativePanel>
-                            <FontIcon x:Name="dbHomeGlyph" Style="{StaticResource SplitViewGlyph}" Glyph="&#xE10F;"></FontIcon>
-                            <TextBlock x:Uid="Home" RelativePanel.RightOf="dbHomeGlyph" RelativePanel.AlignVerticalCenterWith="dbHomeGlyph"
-                                       Visibility="{x:Bind mainSplitView.IsPaneOpen, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">DbHome placeholder</TextBlock>
-                        </RelativePanel>
-                    </ListViewItem>
+                <muxc:NavigationViewItem x:Uid="HomeNav" Content="HomePlaceholder" x:Name="homeNavItem"
+                    Visibility="{x:Bind ViewModel.DecryptedDatabase, Converter={StaticResource ExistenceToVisibilityConverter}, Mode=OneWay}">
+                    <muxc:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE10F;" />
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
 
-                    <ListViewItem x:Name="passwordItem">
-                        <RelativePanel>
-                            <FontIcon x:Name="passwordGlyph" Style="{StaticResource SplitViewGlyph}" Glyph="&#xE8D7;"></FontIcon>
-                            <TextBlock x:Uid="PasswordGen" RelativePanel.RightOf="passwordGlyph" RelativePanel.AlignVerticalCenterWith="passwordGlyph"
-                                       Visibility="{x:Bind mainSplitView.IsPaneOpen, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">Password placeholder</TextBlock>
-                        </RelativePanel>
-                        
-                        <FlyoutBase.AttachedFlyout>
-                            <Flyout Placement="Right">
-                                <StackPanel Orientation="Vertical" Width="286" DataContext="{x:Bind ViewModel.PasswordGenViewModel, Mode=OneWay}"
+                <muxc:NavigationViewItem x:Uid="PasswordNav" Content="PasswordPlaceholder" x:Name="passwordNavItem">
+                    <muxc:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE8D7;" />
+                    </muxc:NavigationViewItem.Icon>
+
+                    <FlyoutBase.AttachedFlyout>
+                        <Flyout Placement="Right" Closing="Flyout_Closing">
+                            <StackPanel Orientation="Vertical" Width="286" DataContext="{x:Bind ViewModel.PasswordGenViewModel, Mode=OneWay}"
                                             Margin="0" Padding="0">
-                                    <StackPanel.Resources>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="FontSize" Value="16" />
-                                        </Style>
-                                        <Style TargetType="TextBox">
-                                            <Setter Property="Margin" Value="6" />
-                                        </Style>
-                                    </StackPanel.Resources>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock>
+                                <StackPanel.Resources>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="FontSize" Value="16" />
+                                    </Style>
+                                    <Style TargetType="TextBox">
+                                        <Setter Property="Margin" Value="6" />
+                                    </Style>
+                                </StackPanel.Resources>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock>
                                             <Run x:Uid="PasswordGenLengthInfo">Password length prompt</Run><Run>&#160;</Run>
-                                        </TextBlock>
-                                        <TextBlock Text="{x:Bind lengthSlider.Value, Mode=OneWay}" />
-                                    </StackPanel>
-                                    <Slider x:Name="lengthSlider" Minimum="4" Maximum="50" Value="{Binding Length, Mode=TwoWay}" Width="262" Margin="10" StepFrequency="1" HorizontalAlignment="Left" />
+                                    </TextBlock>
+                                    <TextBlock Text="{x:Bind lengthSlider.Value, Mode=OneWay}" />
+                                </StackPanel>
+                                <Slider x:Name="lengthSlider" Minimum="4" Maximum="50" Value="{Binding Length, Mode=TwoWay}" Width="262" Margin="10" StepFrequency="1" HorizontalAlignment="Left" />
 
-                                    <TextBlock x:Uid="PasswordGenAllowedCharsHeader">Allowed chars placeholder</TextBlock>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="*" />
-                                            <RowDefinition Height="*" />
-                                            <RowDefinition Height="*" />
-                                            <RowDefinition Height="*" />
-                                        </Grid.RowDefinitions>
+                                <TextBlock x:Uid="PasswordGenAllowedCharsHeader">Allowed chars placeholder</TextBlock>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
 
-                                        <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeUpperAlpha"
+                                    <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeUpperAlpha"
                                                       IsChecked="{Binding UseUpperCase, Mode=TwoWay}">ABCDEFGHIJ...</CheckBox>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeLowerAlpha"
+                                    <StackPanel Grid.Column="1" Grid.Row="0" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeLowerAlpha"
                                                       IsChecked="{Binding UseLowerCase, Mode=TwoWay}">acdefghij...</CheckBox>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Grid.Column="0" Grid.Row="1" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeDigits"
+                                    <StackPanel Grid.Column="0" Grid.Row="1" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeDigits"
                                                       IsChecked="{Binding UseDigits, Mode=TwoWay}">0123456789</CheckBox>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeSpace"
+                                    <StackPanel Grid.Column="1" Grid.Row="1" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeSpace"
                                                       IsChecked="{Binding UseSpace, Mode=TwoWay}">Space</CheckBox>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeSymbols"
+                                    <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeSymbols"
                                                       IsChecked="{Binding UseSymbols, Mode=TwoWay}">.!?@#$%^&amp;*&apos;&quot;`\/</CheckBox>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeBrackets"
+                                    <StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeBrackets"
                                                       IsChecked="{Binding UseBrackets, Mode=TwoWay}">[]{}()&lt;&gt;</CheckBox>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeMinus"
+                                    <StackPanel Grid.Column="0" Grid.Row="3" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeMinus"
                                                       IsChecked="{Binding UseMinus, Mode=TwoWay}">Minus -</CheckBox>
-                                        </StackPanel>
+                                    </StackPanel>
 
-                                        <StackPanel Grid.Column="1" Grid.Row="3" Orientation="Horizontal">
-                                            <CheckBox x:Uid="PasswordGenIncludeUnderscore"
+                                    <StackPanel Grid.Column="1" Grid.Row="3" Orientation="Horizontal">
+                                        <CheckBox x:Uid="PasswordGenIncludeUnderscore"
                                                       IsChecked="{Binding UseUnderscore, Mode=TwoWay}">Underscore _</CheckBox>
-                                        </StackPanel>
-                                    </Grid>
+                                    </StackPanel>
+                                </Grid>
 
-                                    <TextBlock x:Uid="PasswordGenAlsoAllowHeader">Also allow these characters</TextBlock>
-                                    <TextBox x:Uid="PasswordGenAlsoAllowBox" Text="{x:Bind ViewModel.PasswordGenViewModel.AllowList, Mode=TwoWay}">
-                                        <ToolTipService.ToolTip>
-                                            Placeholder
-                                        </ToolTipService.ToolTip>
-                                    </TextBox>
+                                <TextBlock x:Uid="PasswordGenAlsoAllowHeader">Also allow these characters</TextBlock>
+                                <TextBox x:Uid="PasswordGenAlsoAllowBox" Text="{x:Bind ViewModel.PasswordGenViewModel.AllowList, Mode=TwoWay}">
+                                    <ToolTipService.ToolTip>
+                                        Placeholder
+                                    </ToolTipService.ToolTip>
+                                </TextBox>
 
-                                    <TextBlock x:Uid="PasswordGenExcludeHeader">Exclude these characters</TextBlock>
-                                    <TextBox x:Uid="PasswordGenExcludeBox" Text="{x:Bind ViewModel.PasswordGenViewModel.ExcludeList, Mode=TwoWay}">
-                                        <ToolTipService.ToolTip>
-                                            Placeholder
-                                        </ToolTipService.ToolTip>
-                                    </TextBox>
+                                <TextBlock x:Uid="PasswordGenExcludeHeader">Exclude these characters</TextBlock>
+                                <TextBox x:Uid="PasswordGenExcludeBox" Text="{x:Bind ViewModel.PasswordGenViewModel.ExcludeList, Mode=TwoWay}">
+                                    <ToolTipService.ToolTip>
+                                        Placeholder
+                                    </ToolTipService.ToolTip>
+                                </TextBox>
 
-                                    <TextBlock x:Uid="PasswordGenGenerateToLabel">Generate to...</TextBlock>
-                                    <Grid>
-                                        <!-- TODO
+                                <TextBlock x:Uid="PasswordGenGenerateToLabel">Generate to...</TextBlock>
+                                <Grid>
+                                    <!-- TODO
                                         <Button x:Uid="PasswordGenPasswordBoxButton" Margin="5">
                                             Password Box
                                             <ToolTipService.ToolTip>
@@ -303,54 +150,82 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                                             </ToolTipService.ToolTip>
                                         </Button>
                                         -->
-                                        <Button x:Uid="PasswordBoxGenPasswordClipboardButton" Margin="5"
+                                    <Button x:Uid="PasswordBoxGenPasswordClipboardButton" Margin="5"
                                                 Command="{x:Bind ViewModel.PasswordGenViewModel.ClipboardCopyCommand}">
-                                            Clipboard
-                                            <ToolTipService.ToolTip>
-                                                Placeholder
-                                            </ToolTipService.ToolTip>
-                                        </Button>
-                                    </Grid>
-                                </StackPanel>
-                            </Flyout>
-                        </FlyoutBase.AttachedFlyout>
-                    </ListViewItem>
+                                        Clipboard
+                                        <ToolTipService.ToolTip>
+                                            Placeholder
+                                        </ToolTipService.ToolTip>
+                                    </Button>
+                                </Grid>
+                            </StackPanel>
+                        </Flyout>
+                    </FlyoutBase.AttachedFlyout>
+                </muxc:NavigationViewItem>
 
-                    <ListViewItem x:Name="helpItem">
-                        <RelativePanel>
-                            <FontIcon x:Name="helpGlyph" Style="{StaticResource SplitViewGlyph}" Glyph="&#xE11B;"></FontIcon>
-                            <TextBlock x:Uid="Help" RelativePanel.RightOf="helpGlyph" RelativePanel.AlignVerticalCenterWith="helpGlyph"
-                                       Visibility="{x:Bind mainSplitView.IsPaneOpen, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">Help placeholder</TextBlock>
-                        </RelativePanel>
-                    </ListViewItem>
+                <muxc:NavigationViewItem x:Uid="HelpNav" Content="HelpPlaceholder" x:Name="helpNavItem">
+                    <muxc:NavigationViewItem.Icon>
+                        <FontIcon  Glyph="&#xE11B;" />
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+            </muxc:NavigationView.MenuItems>
 
-                    <ListViewItem x:Name="settingsItem">
-                        <RelativePanel>
-                            <FontIcon x:Name="settingsGlyph" Style="{StaticResource SplitViewGlyph}" Glyph="&#xE115;"></FontIcon>
-                            <TextBlock x:Uid="Settings" RelativePanel.RightOf="settingsGlyph" RelativePanel.AlignVerticalCenterWith="settingsGlyph"
-                                       Visibility="{x:Bind mainSplitView.IsPaneOpen, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">Settings placeholder</TextBlock>
-                        </RelativePanel>
-                    </ListViewItem>
-                    <!-- Use SelectionChanged for nav -->
-                </ListView>
-            </SplitView.Pane>
-            <SplitView.Content>
-                <RelativePanel>
-                    <!-- ProgressBar for clearing clipboard automatically -->
-                    <!-- Removed in favor of chrome number indicator -->
-                    <!-- <ProgressBar x:Name="clipboardClearProgressBar" Minimum="0" Maximum="1" Foreground="{StaticResource GroupBorderColor}" Background="{StaticResource EntryBorderColor}"
-                                 RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
-                                 RelativePanel.AlignBottomWithPanel="True"
-                                 Value="{x:Bind ViewModel.ClipboardClearViewModel.NormalizedTimeRemaining, Mode=OneWay}"
-                                 Margin="0" Height="5" /> -->
-                    
-                    <Frame x:Name="contentFrame" Navigated="ContentFrame_Navigated"
-                           RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
-                           RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignBottomWithPanel="True"
-                           IsEnabled="{x:Bind ViewModel.TaskNotificationService.CurrentTask.IsCompleted, Mode=OneWay, FallbackValue=true}"/>
+            <!--
+            <muxc:NavigationView.AutoSuggestBox>
+                <AutoSuggestBox />
+            </muxc:NavigationView.AutoSuggestBox>
+            -->
+
+            <!--
+            <muxc:NavigationView.HeaderTemplate>
+                <DataTemplate x:DataType="fw:RootView">
+
+                </DataTemplate>
+            </muxc:NavigationView.HeaderTemplate>
+            -->
+
+            <RelativePanel>
+                <!-- "Chrome" -->
+                <RelativePanel x:Name="appChrome" Background="{ThemeResource AppBarBackgroundThemeBrush}"
+                       RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True">
+
+                    <!-- Clipboard clear timer -->
+                    <RelativePanel Height="30" RelativePanel.LeftOf="savingIndicator" RelativePanel.AlignVerticalCenterWithPanel="True"
+                           Margin="0,0,10,0"
+                           Visibility="{x:Bind ViewModel.ClipboardClearViewModel.TimeRemainingInSeconds, Mode=OneWay, Converter={StaticResource NonZeroDoubleToVisibilityConverter}}">
+                        <TextBlock x:Name="clipboardClearIcon" FontFamily="Segoe MDL2 Assets" Text="&#xE16D;" FontSize="20"
+                           RelativePanel.AlignRightWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True" />
+                        <Border x:Name="clipboardClearTimerText" BorderBrush="{x:Null}"
+                        RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignBottomWithPanel="True"
+                        RelativePanel.LeftOf="clipboardClearIcon">
+                            <TextBlock x:Name="clipboardClearTimer" FontSize="20"
+                               Text="{x:Bind ViewModel.ClipboardClearViewModel.TimeRemainingInSeconds, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0.0}'}"/>
+                        </Border>
+                    </RelativePanel>
+
+                    <!-- Saving progress indicator -->
+                    <RelativePanel x:Name="savingIndicator" x:Uid="SavingIndicator" Height="30" Margin="0,0,10,0"
+                            RelativePanel.AlignRightWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True"
+                            Visibility="{x:Bind ViewModel.IsSaving, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <ProgressRing x:Name="savingIndicatorRing" Height="30" Width="30" Foreground="{ThemeResource AppBarItemForegroundThemeBrush}" IsActive="True"
+                              RelativePanel.AlignHorizontalCenterWithPanel="True" RelativePanel.AlignVerticalCenterWithPanel="True" />
+                        <FontIcon FontSize="12" Foreground="{ThemeResource AppBarItemForegroundThemeBrush}" FontFamily="Segoe MDL2 Assets"
+                          Glyph="&#xE105;" RelativePanel.AlignHorizontalCenterWith="savingIndicatorRing" RelativePanel.AlignVerticalCenterWith="savingIndicatorRing" />
+                    </RelativePanel>
                 </RelativePanel>
-            </SplitView.Content>
-        </SplitView>
+
+                <ContentControl x:Name="RootCommandBar" Content="{x:Bind CommandBar, Mode=OneWay}"
+                            Visibility="{x:Bind HasActiveCommandBar, Mode=OneWay}"
+                            RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
+                            RelativePanel.AlignBottomWithPanel="True">
+                </ContentControl>
+
+                <Frame x:Name="contentFrame" Navigated="ContentFrame_Navigated" Grid.Row="1"
+                       RelativePanel.AlignTopWithPanel="True" RelativePanel.Above="RootCommandBar"
+                       RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
+                       IsEnabled="{x:Bind ViewModel.TaskNotificationService.CurrentTask.IsCompleted, Mode=OneWay, FallbackValue=true}" />
+            </RelativePanel>
+        </muxc:NavigationView>
 
         <!-- "Loading" progressbar -->
         <RelativePanel x:Name="loadingPane"
@@ -378,5 +253,5 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
             </RelativePanel>
         </RelativePanel>
 
-    </RelativePanel>
+    </Grid>
 </vb:RootViewBase>

--- a/PassKeep.App/Framework/RootView.xaml
+++ b/PassKeep.App/Framework/RootView.xaml
@@ -55,7 +55,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                     <FlyoutBase.AttachedFlyout>
                         <Flyout Placement="Right" Closing="Flyout_Closing">
                             <StackPanel Orientation="Vertical" Width="286" DataContext="{x:Bind ViewModel.PasswordGenViewModel, Mode=OneWay}"
-                                            Margin="0" Padding="0">
+                                            Margin="0" Padding="0" Background="{ThemeResource SystemControlAcrylicWindowBrush}">
                                 <StackPanel.Resources>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="FontSize" Value="16" />
@@ -171,11 +171,15 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
             </muxc:NavigationView.MenuItems>
 
             <!--
+            Hard to use the NavigationView AutoSuggestBox until I can figure out
+            how to properly plumb search down to an unlocked database.
             <muxc:NavigationView.AutoSuggestBox>
-                <AutoSuggestBox />
+                <AutoSuggestBox x:Name="searchBox" x:Uid="SearchBox"
+                                QueryIcon="Find" />
+
             </muxc:NavigationView.AutoSuggestBox>
             -->
-
+            
             <!--
             <muxc:NavigationView.HeaderTemplate>
                 <DataTemplate x:DataType="fw:RootView">
@@ -214,16 +218,28 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                     </RelativePanel>
                 </RelativePanel>
 
-                <ContentControl x:Name="RootCommandBar" Content="{x:Bind CommandBar, Mode=OneWay}"
+                <!-- Content="{x:Bind CommandBar, Mode=OneWay}" -->
+                <ContentControl x:Name="RootCommandBar" 
                             Visibility="{x:Bind HasActiveCommandBar, Mode=OneWay}"
+                                Background="Red" BorderBrush="Blue" BorderThickness="2"
                             RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
                             RelativePanel.AlignBottomWithPanel="True">
-                </ContentControl>
+                    <ContentControl.Content>
+                        <CommandBar>
+                            <CommandBar.PrimaryCommands>
+                                <AppBarButton Icon="Home" Label="Test" />
+                            </CommandBar.PrimaryCommands>
+                        </CommandBar>
+                    </ContentControl.Content>
+                </ContentControl> 
+              
 
                 <Frame x:Name="contentFrame" Navigated="ContentFrame_Navigated" Grid.Row="1"
                        RelativePanel.AlignTopWithPanel="True" RelativePanel.Above="RootCommandBar"
                        RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
                        IsEnabled="{x:Bind ViewModel.TaskNotificationService.CurrentTask.IsCompleted, Mode=OneWay, FallbackValue=true}" />
+
+                
             </RelativePanel>
         </muxc:NavigationView>
 

--- a/PassKeep.App/Framework/RootView.xaml.cs
+++ b/PassKeep.App/Framework/RootView.xaml.cs
@@ -368,9 +368,31 @@ namespace PassKeep.Framework
             this.NavigationView.SelectionChanged += NavigationView_SelectionChanged;
         }
 
-        private void NavigationView_ItemInvoked(MUXC.NavigationView sender, MUXC.NavigationViewItemInvokedEventArgs args)
+        private async void NavigationView_ItemInvoked(MUXC.NavigationView sender, MUXC.NavigationViewItemInvokedEventArgs args)
         {
-            
+            async Task Revert()
+            {
+                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, SynchronizeNavigationViewSelection);
+            }
+
+            if (args.InvokedItemContainer.Equals(this.passwordNavItem))
+            {
+                DebugHelper.Trace("Password Generator selected in NavigationView.");
+                FlyoutBase.ShowAttachedFlyout(this.passwordNavItem);
+            }
+            else if (args.InvokedItemContainer.Equals(this.openNavItem))
+            {
+                DebugHelper.Trace("Open selected in NavigationView.");
+                await PickFileForOpenAndContinueAsync(
+                    /* gotFile */ file =>
+                                  {
+                                      OpenFile(file);
+                                      return Task.CompletedTask;
+                                  },
+                    /* cancelled */
+                    Revert
+                );
+            }
         }
 
         private void NavigationView_BackRequested(MUXC.NavigationView sender, MUXC.NavigationViewBackRequestedEventArgs args)
@@ -378,13 +400,8 @@ namespace PassKeep.Framework
             this.ContentBackCommand.Execute(null);
         }
 
-        private async void NavigationView_SelectionChanged(MUXC.NavigationView sender, MUXC.NavigationViewSelectionChangedEventArgs args)
+        private void NavigationView_SelectionChanged(MUXC.NavigationView sender, MUXC.NavigationViewSelectionChangedEventArgs args)
         {
-            async Task Revert()
-            {
-                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, SynchronizeNavigationViewSelection);
-            }
-
             if (args.IsSettingsSelected)
             {
                 DebugHelper.Trace("Settings selected in NavigationView.");
@@ -401,28 +418,10 @@ namespace PassKeep.Framework
                 DebugHelper.Assert(ViewModel.DecryptedDatabase != null, "This button should not be accessible if there is not decrypted database");
                 ContentFrame.Navigate(typeof(DatabaseParentView), ViewModel.DecryptedDatabase);
             }
-            else if (args.SelectedItemContainer.Equals(this.passwordNavItem))
-            {
-                DebugHelper.Trace("Password Generator selected in NavigationView.");
-                FlyoutBase.ShowAttachedFlyout(this.passwordNavItem);
-            }
             else if (args.SelectedItemContainer.Equals(this.helpNavItem))
             {
                 DebugHelper.Trace("Help selected in NavigationView.");
                 ContentFrame.Navigate(typeof(HelpView));
-            }
-            else if (args.SelectedItemContainer.Equals(this.openNavItem))
-            {
-                DebugHelper.Trace("Open selected in NavigationView.");
-                await PickFileForOpenAndContinueAsync(
-                    /* gotFile */ file =>
-                                  {
-                                      OpenFile(file);
-                                      return Task.CompletedTask;
-                                  },
-                    /* cancelled */
-                    Revert
-                );
             }
         }
 

--- a/PassKeep.App/PassKeep.App.csproj
+++ b/PassKeep.App/PassKeep.App.csproj
@@ -410,6 +410,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.1.7</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.UI.Xaml">
+      <Version>2.4.0</Version>
+    </PackageReference>
     <PackageReference Include="Unity">
       <Version>5.8.9</Version>
     </PackageReference>

--- a/PassKeep.App/PassKeep.App.licenseheader
+++ b/PassKeep.App/PassKeep.App.licenseheader
@@ -1,11 +1,11 @@
 ﻿extensions: .cs
-// Copyright 2020 Steven Fuqua
+// Copyright 2021 Steven Fuqua
 // This file is part of PassKeep and is licensed under the GNU GPL v3.
-// For the full license, see gpl-3.0.md in this solution or under https://bitbucket.org/sapph/passkeep/src
+// For the full license, see gpl-3.0.md in this solution or under https://github.com/sfuqua/passkeep
 
 extensions: .xaml
 <!--
-Copyright 2020 Steven Fuqua
+Copyright 2021 Steven Fuqua
 This file is part of PassKeep and is licensed under the GNU GPL v3.
-For the full license, see gpl-3.0.md in this solution or under https://bitbucket.org/sapph/passkeep/src
+For the full license, see gpl-3.0.md in this solution or under https://github.com/sfuqua/passkeep
 -->

--- a/PassKeep.App/ResourceDictionaries/DataTemplateDictionary.xaml
+++ b/PassKeep.App/ResourceDictionaries/DataTemplateDictionary.xaml
@@ -10,10 +10,98 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:PassKeep.ResourceDictionaries"
     xmlns:vm="using:PassKeep.Lib.Contracts.ViewModels"
-    xmlns:model="using:PassKeep.Lib.Contracts.Models">
+    xmlns:model="using:PassKeep.Lib.Contracts.Models"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls">
 
     <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
-    
+
+    <DataTemplate x:Key="GroupTemplate_Tree"  x:DataType="vm:IDatabaseGroupViewModel">
+        <muxc:TreeViewItem ItemsSource="{Binding Children, Mode=OneWay}">
+            <RelativePanel Height="30" RightTapped="NodeRightTapped" Background="Transparent"
+                    AllowDrop="True" DragEnter="Group_DragEnter" Drop="Group_Drop">
+
+                <RelativePanel.Transitions>
+                    <TransitionCollection>
+                        <EntranceThemeTransition/>
+                    </TransitionCollection>
+                </RelativePanel.Transitions>
+            
+                <FlyoutBase.AttachedFlyout>
+                    <MenuFlyout Placement="Right">
+                        <MenuFlyoutItem x:Uid="OpenContextItem" Command="{x:Bind RequestOpenCommand}" />
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem x:Uid="Rename" Command="{x:Bind RequestRenameCommand}" />
+                        <MenuFlyoutItem x:Uid="Details" Command="{x:Bind RequestEditDetailsCommand}" />
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem x:Uid="DeleteContextItem" Command="{x:Bind RequestDeleteCommand}" />
+                    </MenuFlyout>
+                </FlyoutBase.AttachedFlyout>
+
+                <FontIcon FontFamily="{x:Bind Node, Converter={StaticResource NodeToFontConverter}, Mode=OneWay}"
+                            Glyph="{x:Bind Node, Converter={StaticResource NodeToIconConverter}, Mode=OneWay}"
+                            RelativePanel.AlignVerticalCenterWithPanel="True"
+                            x:Name="glyph" />
+
+                <TextBlock Text="{x:Bind Node.Title.ClearValue, Mode=OneWay}" 
+                            RelativePanel.AlignVerticalCenterWithPanel="True" RelativePanel.RightOf="glyph"
+                            VerticalAlignment="Center" Margin="8,0,0,0" />
+            </RelativePanel>
+        </muxc:TreeViewItem> 
+    </DataTemplate>
+
+    <DataTemplate x:Key="EntryTemplate_Tree"  x:DataType="vm:IDatabaseEntryViewModel">
+        <muxc:TreeViewItem>
+            <RelativePanel RightTapped="NodeRightTapped" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <RelativePanel.Transitions>
+                    <TransitionCollection>
+                        <EntranceThemeTransition/>
+                    </TransitionCollection>
+                </RelativePanel.Transitions>
+
+                <FlyoutBase.AttachedFlyout>
+                    <MenuFlyout Placement="Right">
+                        <MenuFlyoutItem x:Uid="CopyUsername" Command="{x:Bind RequestCopyUsernameCommand}" />
+                        <MenuFlyoutItem x:Uid="CopyPassword" Command="{x:Bind RequestCopyPasswordCommand}" />
+                        <MenuFlyoutItem x:Uid="LaunchUrlContextItem" Command="{x:Bind RequestLaunchUrlCommand}" />
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem x:Uid="Rename" Command="{x:Bind RequestRenameCommand}" />
+                        <MenuFlyoutItem x:Uid="Details" Command="{x:Bind RequestEditDetailsCommand}" />
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem x:Uid="DeleteContextItem" Command="{x:Bind RequestDeleteCommand}" />
+                    </MenuFlyout>
+                </FlyoutBase.AttachedFlyout>
+
+                <FontIcon FontSize="24" x:Name="glyph"
+                              FontFamily="{x:Bind Node, Converter={StaticResource NodeToFontConverter}, Mode=OneWay}"
+                              Glyph="{x:Bind Node, Converter={StaticResource NodeToIconConverter}, Mode=OneWay}"
+                          RelativePanel.AlignVerticalCenterWithPanel="True"
+                              />
+
+                <TextBlock Text="{x:Bind Node.Title.ClearValue, Mode=OneWay}" 
+                               VerticalAlignment="Center" Margin="8,0,0,0"
+                           RelativePanel.AlignVerticalCenterWithPanel="True" RelativePanel.RightOf="glyph"/>
+
+                <!--
+                <Button x:Uid="CopyCredentialsButton" FontFamily="Segoe MDL2 Assets" FontSize="20"
+                            RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignRightWithPanel="True"
+                            Width="40" Height="40" Padding="0"
+                            Content="&#xE16D;">
+                    <Button.Flyout>
+                        <MenuFlyout Placement="Right">
+                            <MenuFlyoutItem x:Uid="CopyUsername"
+                                                Command="{Binding RequestCopyUsernameCommand}" />
+                            <MenuFlyoutItem x:Uid="CopyPassword"
+                                                Command="{Binding RequestCopyPasswordCommand}" />
+                            <MenuFlyoutItem x:Uid="LaunchUrlContextItem"
+                                                Command="{Binding RequestLaunchUrlCommand}" />
+                        </MenuFlyout>
+                    </Button.Flyout>
+                </Button>
+                -->
+            </RelativePanel>
+        </muxc:TreeViewItem>
+    </DataTemplate>
+
     <DataTemplate x:Key="GroupTemplate"><!-- x:DataType="vm:IDatabaseNodeViewModel"> -->
         <Border BorderBrush="{StaticResource GroupBorderColor}" BorderThickness="2" RightTapped="NodeRightTapped"
                 AllowDrop="True" DragEnter="Group_DragEnter" Drop="Group_Drop">

--- a/PassKeep.App/ResourceDictionaries/DataTemplateDictionary.xaml
+++ b/PassKeep.App/ResourceDictionaries/DataTemplateDictionary.xaml
@@ -163,6 +163,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                            RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True" />
   
                 <Button x:Uid="CopyCredentialsButton" FontFamily="Segoe MDL2 Assets" FontSize="20"
+                        Style="{StaticResource ButtonRevealStyle}"
                         RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignRightWithPanel="True"
                         Width="40" Height="40" Padding="0"
                         Content="&#xE16D;">

--- a/PassKeep.App/ResourceDictionaries/DataTemplateDictionary.xaml.cs
+++ b/PassKeep.App/ResourceDictionaries/DataTemplateDictionary.xaml.cs
@@ -10,6 +10,7 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
 using PassKeep.Lib.Contracts.Models;
+using MUXC = Microsoft.UI.Xaml.Controls;
 
 namespace PassKeep.ResourceDictionaries
 {
@@ -38,7 +39,8 @@ namespace PassKeep.ResourceDictionaries
             FrameworkElement senderElement = sender as FrameworkElement;
             DebugHelper.Assert(senderElement != null);
 
-            IDatabaseGroupViewModel groupVm = senderElement.DataContext as IDatabaseGroupViewModel;
+            GroupTreeViewNode groupNode = senderElement.DataContext as GroupTreeViewNode;
+            IDatabaseGroupViewModel groupVm = groupNode?.GroupViewModel ?? senderElement.DataContext as IDatabaseGroupViewModel;
             DebugHelper.Assert(groupVm != null);
 
             IKeePassGroup thisGroup = groupVm.Node as IKeePassGroup;
@@ -67,7 +69,8 @@ namespace PassKeep.ResourceDictionaries
             FrameworkElement senderElement = sender as FrameworkElement;
             DebugHelper.Assert(senderElement != null);
 
-            IDatabaseGroupViewModel groupVm = senderElement.DataContext as IDatabaseGroupViewModel;
+            GroupTreeViewNode groupNode = senderElement.DataContext as GroupTreeViewNode;
+            IDatabaseGroupViewModel groupVm = groupNode?.GroupViewModel ?? senderElement.DataContext as IDatabaseGroupViewModel;
             DebugHelper.Assert(groupVm != null);
 
             IKeePassGroup thisGroup = groupVm.Node as IKeePassGroup;
@@ -84,5 +87,53 @@ namespace PassKeep.ResourceDictionaries
 
             deferral.Complete();
         }
+
+        private void RelativePanel_RightTapped(object sender, RightTappedRoutedEventArgs e)
+        {
+
+        }
+    }
+
+    /// <summary>
+    /// Slim wrapper that allows using <see cref="IDatabaseGroupViewModel"/> in a TreeView.
+    /// </summary>
+    public sealed class GroupTreeViewNode: MUXC.TreeViewNode
+    {
+        public static readonly DependencyProperty IsLoadingProperty = DependencyProperty.Register(
+            "IsLoading", typeof(bool), typeof(GroupTreeViewNode),
+            PropertyMetadata.Create(false)
+        );
+
+        public GroupTreeViewNode(IDatabaseGroupViewModel group) : base()
+        {
+            Content = group;
+            GroupViewModel = group;
+        }
+
+        public bool IsLoading
+        {
+            get => (bool)GetValue(IsLoadingProperty);
+            set => SetValue(IsLoadingProperty, value);
+        }
+
+        public IDatabaseGroupViewModel GroupViewModel { get; }
+
+        public IKeePassGroup Group => (IKeePassGroup)GroupViewModel.Node;
+    }
+
+    /// <summary>
+    /// Slim wrapper that allows using <see cref="IDatabaseEntryViewModel"/> in a TreeView.
+    /// </summary>
+    public sealed class EntryTreeViewNode : MUXC.TreeViewNode
+    {
+        public EntryTreeViewNode(IDatabaseEntryViewModel entry) : base()
+        {
+            Content = entry;
+            EntryViewModel = entry;
+        }
+
+        public IDatabaseEntryViewModel EntryViewModel { get; }
+
+        public IKeePassEntry Entry => (IKeePassEntry)EntryViewModel.Node;
     }
 }

--- a/PassKeep.App/Strings/en-US/Resources.resw
+++ b/PassKeep.App/Strings/en-US/Resources.resw
@@ -777,4 +777,19 @@ sample database structure.</value>
   <data name="MasterKeyStorageNotice.Text" xml:space="preserve">
     <value>If you have a saved password for this file, it will be deleted. You can save the new password next time you unlock the database.</value>
   </data>
+  <data name="DashboardNav.Content" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="OpenNav.Content" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="HelpNav.Content" xml:space="preserve">
+    <value>Help</value>
+  </data>
+  <data name="HomeNav.Content" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="PasswordNav.Content" xml:space="preserve">
+    <value>Password Tool</value>
+  </data>
 </root>

--- a/PassKeep.App/Views/Controls/BreadcrumbNavigator.xaml
+++ b/PassKeep.App/Views/Controls/BreadcrumbNavigator.xaml
@@ -97,7 +97,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                         </VisualState>
                     </VisualStateGroup>
                 </VisualStateManager.VisualStateGroups>
-                <Grid Background="{TemplateBinding Background}">
+                <Grid Background="{ThemeResource SystemControlAccentDark1AcrylicElementAccentDark1Brush}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />

--- a/PassKeep.App/Views/DashboardView.xaml
+++ b/PassKeep.App/Views/DashboardView.xaml
@@ -233,6 +233,9 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                         Click="NewDatabase_Click"
                         Style="{StaticResource DatabaseButton}">
                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE132;"></FontIcon>
+                    <Button.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="F1" />
+                    </Button.KeyboardAccelerators>
                 </Button>
                 <TextBlock x:Uid="NewDatabaseLabel" Text="New" Style="{StaticResource DatabaseButtonLabel}"
                            RelativePanel.Below="newDatabaseButton" RelativePanel.AlignHorizontalCenterWith="newDatabaseButton" />
@@ -241,6 +244,9 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                         Click="OpenFile_Click" RelativePanel.RightOf="newDatabaseButton"
                         Style="{StaticResource DatabaseButton}">
                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE1A5;"></FontIcon>
+                    <Button.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="F2" />
+                    </Button.KeyboardAccelerators>
                 </Button>
                 <TextBlock x:Uid="OpenDatabaseLabel" Text="Open" Style="{StaticResource DatabaseButtonLabel}"
                            RelativePanel.Below="openDatabaseButton" RelativePanel.AlignHorizontalCenterWith="openDatabaseButton" />
@@ -249,6 +255,9 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                         Click="OpenSample_Click" RelativePanel.RightOf="openDatabaseButton"
                         Style="{StaticResource DatabaseButton}">
                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE1F6;"></FontIcon>
+                    <Button.KeyboardAccelerators>
+                        <KeyboardAccelerator Key="F3" />
+                    </Button.KeyboardAccelerators>
                 </Button>
                 <TextBlock x:Uid="SampleDatabaseLabel" Text="Sample" Style="{StaticResource DatabaseButtonLabel}"
                            RelativePanel.Below="sampleDatabaseButton" RelativePanel.AlignHorizontalCenterWith="sampleDatabaseButton" />

--- a/PassKeep.App/Views/DashboardView.xaml
+++ b/PassKeep.App/Views/DashboardView.xaml
@@ -20,7 +20,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
 
     <view:DashboardViewBase.Resources>
         <x:String x:Key="ChevronGlyph">&#xE26B;</x:String>
-        <Style x:Name="DatabaseButton" TargetType="Button">
+        <Style x:Name="DatabaseButton" TargetType="Button" BasedOn="{StaticResource ButtonRevealStyle}">
             <Setter Property="Margin" Value="10,0" />
             <Setter Property="Height" Value="65" />
             <Setter Property="Width" Value="65" />
@@ -320,7 +320,8 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                                 
                                 <Button x:Name="delete"
                                         RelativePanel.AlignTopWithPanel="True" RelativePanel.AlignRightWithPanel="True"
-                                        Command="{x:Bind ForgetCommand}">
+                                        Command="{x:Bind ForgetCommand}"
+                                        Style="{StaticResource ButtonRevealStyle}">
                                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10A;"/>
                                 </Button>
                             </RelativePanel>

--- a/PassKeep.App/Views/DatabaseParentView.xaml.cs
+++ b/PassKeep.App/Views/DatabaseParentView.xaml.cs
@@ -62,13 +62,10 @@ namespace PassKeep.Views
             PassKeepPage newPage = ContentFrame.Content as PassKeepPage;
             DebugHelper.Assert(newPage != null);
 
-            if (newPage.BottomAppBar == null)
+            if (newPage.CommandBar == null)
             {
-                newPage.BottomAppBar = new CommandBar();
+                newPage.CommandBar = new CommandBar();
             }
-
-            CommandBar commandBar = newPage.BottomAppBar as CommandBar;
-            DebugHelper.Assert(commandBar != null);
 
             AppBarButton lockButton = new AppBarButton
             {
@@ -111,9 +108,9 @@ namespace PassKeep.Views
             masterKeyButton.Click += MasterKeyButtonClick;
             masterKeyButton.SetBinding(IsEnabledProperty, enabledBinding);
 
-            commandBar.SecondaryCommands.Add(lockButton);
-            commandBar.SecondaryCommands.Add(settingsButton);
-            commandBar.SecondaryCommands.Add(masterKeyButton);
+            newPage.CommandBar.SecondaryCommands.Add(lockButton);
+            newPage.CommandBar.SecondaryCommands.Add(settingsButton);
+            newPage.CommandBar.SecondaryCommands.Add(masterKeyButton);
         }
 
 
@@ -212,22 +209,6 @@ namespace PassKeep.Views
         #endregion
 
         /// <summary>
-        /// Handles PropertyChanged events from the persistence service.
-        /// </summary>
-        /// <param name="sender">The persistence service.</param>
-        /// <param name="e">EventArgs for the property change.</param>
-        private void PersistenceServicePropertyChangedHandler(object sender, PropertyChangedEventArgs e)
-        {
-            IDatabasePersistenceService service = sender as IDatabasePersistenceService;
-            DebugHelper.Assert(service != null);
-
-            if (e.PropertyName == nameof(service.IsSaving))
-            {
-                MessageBus.Publish(new SavingStateChangeMessage(service.IsSaving));
-            }
-        }
-
-        /// <summary>
         /// Handles lock events from child AppBars.
         /// </summary>
         /// <param name="sender"></param>
@@ -268,10 +249,7 @@ namespace PassKeep.Views
             Frame.BackStack.Clear();
 
             MessageBus.Publish(new DatabaseClosedMessage());
-
-            SystemNavigationManager.AppViewBackButtonVisibility =
-                (CanGoBack() ? AppViewBackButtonVisibility.Visible : AppViewBackButtonVisibility.Collapsed);
-            DebugHelper.Assert(SystemNavigationManager.AppViewBackButtonVisibility == AppViewBackButtonVisibility.Collapsed);
+            RaiseCanGoBackChanged();
         }
 
         /// <summary>
@@ -309,8 +287,6 @@ namespace PassKeep.Views
 
             Window.Current.CoreWindow.KeyDown += CoreWindow_KeyDown;
             Window.Current.CoreWindow.PointerPressed += CoreWindow_PointerPressed;
-
-            ViewModel.PersistenceService.PropertyChanged += PersistenceServicePropertyChangedHandler;
         }
 
         /// <summary>
@@ -322,8 +298,6 @@ namespace PassKeep.Views
             base.OnNavigatedFrom(e);
             Window.Current.CoreWindow.KeyDown -= CoreWindow_KeyDown;
             Window.Current.CoreWindow.PointerPressed -= CoreWindow_PointerPressed;
-
-            ViewModel.PersistenceService.PropertyChanged -= PersistenceServicePropertyChangedHandler;
         }
 
         /// <summary>

--- a/PassKeep.App/Views/DatabaseUnlockView.xaml
+++ b/PassKeep.App/Views/DatabaseUnlockView.xaml
@@ -229,6 +229,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
 
                     <RelativePanel x:Name="keyfilePanel" RelativePanel.Below="keyfileLabel" Width="{x:Bind passwordBox.Width}">
                         <Button x:Name="chooseKeyfileButton" x:Uid="ChooseKeyfileButton"
+                                Style="{StaticResource ButtonRevealStyle}"
                                 RelativePanel.AlignVerticalCenterWithPanel="True"
                                 FontFamily="Segoe UI Symbol" FontSize="24" FontWeight="ExtraLight"
                                 BorderThickness="0" Padding="0,0,0,0" Background="Transparent"
@@ -275,12 +276,14 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                     </CheckBox>
 
                     <Button x:Name="unlockButton" x:Uid="UnlockButton"
+                            Style="{StaticResource ButtonRevealStyle}"
                             RelativePanel.Below="storeCredentialsCheckbox" Margin="0,10,0,0"
                             Command="{x:Bind ViewModel.UnlockCommand, Mode=OneWay}">
                         Unlock Placeholder
                     </Button>
 
                     <Button x:Uid="DifferentDatabaseButton"
+                            Style="{StaticResource ButtonRevealStyle}"
                             RelativePanel.RightOf="unlockButton" Margin="20,10,0,0"
                             RelativePanel.AlignTopWith="unlockButton"
                             Click="DifferentDatabaseButton_Click">

--- a/PassKeep.App/Views/DatabaseView.xaml
+++ b/PassKeep.App/Views/DatabaseView.xaml
@@ -14,6 +14,8 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
     xmlns:view="using:PassKeep.ViewBases"
     xmlns:common="using:PassKeep.Common"
     xmlns:convert="using:PassKeep.Converters"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:vm="using:PassKeep.Lib.Contracts.ViewModels"
     xmlns:dvm="using:PassKeep.ViewModels.DesignTime"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -27,6 +29,27 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
         <Flyout x:Key="nodeRenameFlyout" Placement="Bottom" Closed="{x:Bind RenameFlyout_Closed}">
             <TextBox KeyUp="{x:Bind NodeRenameBox_KeyUp}" />
         </Flyout>
+
+        <!--
+        <Style TargetType="muxc:TreeView">
+            <Setter Property="IsTabStop" Value="False" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="muxc:TreeView">
+                        <muxc:TreeViewList x:Name="ListControl">
+                            <muxc:TreeViewList.ItemContainerTransitions>
+                                <TransitionCollection>
+                                    <ContentThemeTransition />
+                                    <ReorderThemeTransition />
+                                    <EntranceThemeTransition IsStaggeringEnabled="False" />
+                                </TransitionCollection>
+                            </muxc:TreeViewList.ItemContainerTransitions>
+                        </muxc:TreeViewList>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        -->
     </view:DatabaseViewBase.Resources>
 
     <RelativePanel x:Name="contentFrame" Margin="4">
@@ -69,37 +92,56 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
             </AutoSuggestBox.QueryIcon>
         </AutoSuggestBox>
 
-        <!-- Main GridView -->
-        <GridView x:Name="childGridView"
-                  RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
-                  Margin="0,8,0,0"
-                  ItemsSource="{x:Bind ViewModel.SortedChildren, Mode=OneWay}"
-                  ItemTemplateSelector="{StaticResource NodeTemplateSelector}"
-                  IsItemClickEnabled="True"
-                  ItemClick="ChildGridView_ItemClick"
-                  CanDragItems="{Binding PersistenceService.CanSave}"
-                  DragItemsStarting="childGridView_DragItemsStarting" DragItemsCompleted="childGridView_DragItemsCompleted"
-                  SelectionMode="None">
-            <GridView.ItemContainerTransitions>
-                <TransitionCollection>
-                    <EntranceThemeTransition />
-                    <AddDeleteThemeTransition />
-                </TransitionCollection>
-            </GridView.ItemContainerTransitions>
-        </GridView>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="300" />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <muxc:TreeView x:Name="nodeTreeView" Grid.Column="0"
+                RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True"
+                Margin="0,8,0,0"
+                           
+                Visibility="Visible"
+            
+                CanReorderItems="False"
+                CanDragItems="{x:Bind ViewModel.PersistenceService.CanSave, Mode=OneWay}"
+                SelectionMode="None"
+                           
+                ItemsSource="{x:Bind ViewModel.RootGroup.Children, Mode=OneWay}"
+                 ItemTemplateSelector="{StaticResource TreeNodeTemplateSelector}"
+                ItemInvoked="TreeView_ItemInvoked" />
 
-        <!-- Since ItemsSource is an object and casting to a generic ICollection is cumbersome, using {Binding} here -->
-        <Grid Visibility="{Binding ItemsSource.Count, ElementName=childGridView, Converter={StaticResource ItemCountToEmptyLabelVisibilityConverter}}"
-              RelativePanel.Below="searchBox" RelativePanel.AlignHorizontalCenterWithPanel="True"
-			  Margin="0,20,0,0">
-            <TextBlock x:Name="emptyFolderMessage" x:Uid="EmptyFolder" Style="{StaticResource BodyTextBlockStyle}"
-                       Visibility="{x:Bind ViewModel.Filter, Mode=OneWay, Converter={StaticResource EmptyStringToVisibilityConverter}}" />
-            <TextBlock x:Uid="NoSearchResults" Style="{StaticResource BodyTextBlockStyle}"
-                       Visibility="{Binding Visibility, Mode=OneWay, Converter={StaticResource VisibilityNegationConverter}, ElementName=emptyFolderMessage}" />
+            <!-- Main GridView -->
+            <GridView x:Name="childGridView" Grid.Column="1"
+                      Margin="0,40,0,0"
+                      ItemsSource="{x:Bind ViewModel.SortedChildren, Mode=OneWay}"
+                      ItemTemplateSelector="{StaticResource NodeTemplateSelector}"
+                      IsItemClickEnabled="True"
+                      ItemClick="ChildGridView_ItemClick"
+                      CanDragItems="{Binding PersistenceService.CanSave}"
+                      DragItemsStarting="childGridView_DragItemsStarting" DragItemsCompleted="childGridView_DragItemsCompleted"
+                      SelectionMode="None">
+                <GridView.ItemContainerTransitions>
+                    <TransitionCollection>
+                        <EntranceThemeTransition />
+                        <AddDeleteThemeTransition />
+                    </TransitionCollection>
+                </GridView.ItemContainerTransitions>
+            </GridView>
+
+            <!-- Since ItemsSource is an object and casting to a generic ICollection is cumbersome, using {Binding} here -->
+            <Grid Visibility="{Binding ItemsSource.Count, ElementName=childGridView, Converter={StaticResource ItemCountToEmptyLabelVisibilityConverter}}"
+                  Grid.Column="1"
+			      Margin="0,40,0,0">
+                <TextBlock x:Name="emptyFolderMessage" x:Uid="EmptyFolder" Style="{StaticResource BodyTextBlockStyle}"
+                           Visibility="{x:Bind ViewModel.Filter, Mode=OneWay, Converter={StaticResource EmptyStringToVisibilityConverter}}" />
+                <TextBlock x:Uid="NoSearchResults" Style="{StaticResource BodyTextBlockStyle}"
+                           Visibility="{Binding Visibility, Mode=OneWay, Converter={StaticResource VisibilityNegationConverter}, ElementName=emptyFolderMessage}" />
+            </Grid>
         </Grid>
     </RelativePanel>
 
-    <view:DatabaseViewBase.BottomAppBar>
+    <view:DatabaseViewBase.CommandBar>
         <CommandBar DataContext="{x:Bind}">
             <CommandBar.ContentTransitions>
                 <TransitionCollection>
@@ -156,5 +198,5 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                                                     Visibility="{Binding ViewModel.PersistenceService.CanSave, Converter={StaticResource BooleanToVisibilityConverter}}"/>
             </CommandBar.PrimaryCommands>
         </CommandBar>
-    </view:DatabaseViewBase.BottomAppBar>
+    </view:DatabaseViewBase.CommandBar>
 </view:DatabaseViewBase>

--- a/PassKeep.App/Views/DatabaseView.xaml
+++ b/PassKeep.App/Views/DatabaseView.xaml
@@ -142,7 +142,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
     </RelativePanel>
 
     <view:DatabaseViewBase.CommandBar>
-        <CommandBar DataContext="{x:Bind}">
+        <CommandBar DataContext="{x:Bind}" DefaultLabelPosition="Right">
             <CommandBar.ContentTransitions>
                 <TransitionCollection>
 

--- a/PassKeep.App/Views/DatabaseView.xaml.cs
+++ b/PassKeep.App/Views/DatabaseView.xaml.cs
@@ -21,6 +21,11 @@ using Windows.System;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Xaml.Navigation;
 using PassKeep.Lib.Contracts.Enums;
+using MUXC = Microsoft.UI.Xaml.Controls;
+using System.Linq;
+using System.Collections.Generic;
+using PassKeep.ResourceDictionaries;
+using Windows.UI.Core;
 
 namespace PassKeep.Views
 {
@@ -174,6 +179,10 @@ namespace PassKeep.Views
 
                 this.sortModeFlyout.Items.Add(menuItem);
             }
+
+            // This will be handled by data-binding when RS5 ships
+            // 
+            // BuildTreeViewRoot();
         }
 
         /// <summary>
@@ -412,6 +421,7 @@ namespace PassKeep.Views
         /// <param name="e">ClickEventArgs for the action.</param>
         private void ChildGridView_ItemClick(object sender, ItemClickEventArgs e)
         {
+            Trace("+");
             bool wasFiltered = !String.IsNullOrEmpty(this.searchBox.Text);
             if (wasFiltered)
             {
@@ -430,6 +440,7 @@ namespace PassKeep.Views
                 }
 
                 // For now, on item click, navigate to the EntryDetailsView.
+                Trace("Starting navigate to entry detail");
                 Frame.Navigate(
                     typeof(EntryDetailsView),
                     ViewModel.GetEntryDetailsViewModel(entry, /* editing */ false)
@@ -441,8 +452,10 @@ namespace PassKeep.Views
                 IDatabaseGroupViewModel clickedGroup = e.ClickedItem as IDatabaseGroupViewModel;
                 DebugHelper.Assert(clickedGroup != null);
 
+                Trace("Executing group open request");
                 clickedGroup.RequestOpenCommand.Execute(null);
             }
+            Trace("-");
         }
 
         /// <summary>
@@ -500,6 +513,126 @@ namespace PassKeep.Views
             if (args.DropResult == DataPackageOperation.Move)
             {
                 ViewModel.Save();
+            }
+        }
+
+        private async Task BuildTreeViewRoot()
+        {
+            this.nodeTreeView.RootNodes.Clear();
+            await PopulateTreeViewChildren(this.nodeTreeView.RootNodes, ViewModel.Document.Root.DatabaseGroup);
+        }
+
+        private async Task PopulateTreeViewChildren(IList<MUXC.TreeViewNode> unrealizedChildren, IKeePassGroup root)
+        {
+            if (!root.Children.Any())
+            {
+                return;
+            }
+
+            IDatabaseViewModel vm = null;
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                vm = ViewModel;
+            });
+
+            List<MUXC.TreeViewNode> nodes = new List<MUXC.TreeViewNode>();
+
+            foreach (IDatabaseNodeViewModel node in vm.GenerateSortedChildren(root, vm.Filter))
+            {
+                MUXC.TreeViewNode newNode = null;
+                if (node is IDatabaseEntryViewModel entryVm)
+                {
+                    await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    {
+                        newNode = new EntryTreeViewNode(entryVm);
+                    });
+                }
+                else
+                {
+                    IDatabaseGroupViewModel groupVm = node as IDatabaseGroupViewModel;
+                    DebugHelper.Assert(groupVm != null);
+
+                    bool isExpanded = false;
+                    IList<MUXC.TreeViewNode> newChildren = null;
+                    await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    {
+                        newNode = new GroupTreeViewNode(groupVm);
+                        isExpanded = ((GroupTreeViewNode)newNode).Group.IsExpanded;
+                        newNode.IsExpanded = isExpanded;
+                        if (!isExpanded)
+                        {
+                            newNode.HasUnrealizedChildren = ((GroupTreeViewNode)newNode).Group.Children.Any();
+                        }
+                        else
+                        {
+                            newChildren = newNode.Children;
+                        }
+                    });
+                    
+                    if (isExpanded)
+                    {
+                        await PopulateTreeViewChildren(newChildren, ((GroupTreeViewNode)newNode).Group); //.ConfigureAwait(false);
+                    }
+                }
+
+                nodes.Add(newNode);
+            }
+
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                foreach (MUXC.TreeViewNode node in nodes)
+                {
+                    unrealizedChildren.Add(node);
+                }
+            });
+        }
+
+        private async void TreeView_Expanding(MUXC.TreeView sender, MUXC.TreeViewExpandingEventArgs args)
+        {
+            GroupTreeViewNode node = args.Node as GroupTreeViewNode;
+            DebugHelper.Assert(node != null);
+
+            node.IsLoading = true;
+            IList<MUXC.TreeViewNode> children = node.Children;
+            await Task.Run(() => PopulateTreeViewChildren(children, node.Group));
+            node.HasUnrealizedChildren = false;
+            node.IsLoading = false;
+        }
+
+        private void TreeView_Collapsed(MUXC.TreeView sender, MUXC.TreeViewCollapsedEventArgs args)
+        {
+            GroupTreeViewNode node = args.Node as GroupTreeViewNode;
+            DebugHelper.Assert(node != null);
+
+            node.Children.Clear();
+            node.HasUnrealizedChildren = node.GroupViewModel.HasChildren;
+        }
+
+        private void TreeView_ItemInvoked(MUXC.TreeView sender, MUXC.TreeViewItemInvokedEventArgs args)
+        {
+            // Do stuff
+            // First check to see if it's an entry
+            if (args.InvokedItem is IDatabaseEntryViewModel clickedEntry)
+            {
+                IKeePassEntry entry = clickedEntry.Node as IKeePassEntry;
+                DebugHelper.Assert(entry != null);
+                ViewModel.NavigationViewModel.SetGroup(entry.Parent);
+
+                // For now, on item click, navigate to the EntryDetailsView.
+                Trace("Starting navigate to entry detail");
+                Frame.Navigate(
+                    typeof(EntryDetailsView),
+                    ViewModel.GetEntryDetailsViewModel(entry, /* editing */ false)
+                );
+            }
+            else
+            {
+                // We clicked a group, so drill into it...
+                IDatabaseGroupViewModel clickedGroup = args.InvokedItem as IDatabaseGroupViewModel;
+                DebugHelper.Assert(clickedGroup != null);
+
+                Trace("Executing group open request");
+                clickedGroup.RequestOpenCommand.Execute(null);
             }
         }
     }

--- a/PassKeep.App/Views/DatabaseView.xaml.cs
+++ b/PassKeep.App/Views/DatabaseView.xaml.cs
@@ -397,7 +397,8 @@ namespace PassKeep.Views
         /// Handles queries from the SearchBox.
         /// </summary>
         /// <param name="sender">The querying SearchBox.</param>
-        /// <param name="args">Args for the query.</param>
+       
+            /// <param name="args">Args for the query.</param>
         private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
             DebugHelper.Trace($"Handling SearchBox query: {args.QueryText}");

--- a/PassKeep.App/Views/EntryDetailsView.xaml
+++ b/PassKeep.App/Views/EntryDetailsView.xaml
@@ -277,7 +277,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
     </ScrollViewer>
 
     <view:EntryDetailsViewBase.CommandBar>
-        <CommandBar DataContext="{x:Bind}">
+        <CommandBar DataContext="{x:Bind}" DefaultLabelPosition="Right">
             <CommandBar.PrimaryCommands>
                 <AppBarButton Icon="Delete" x:Uid="DeleteField"
                               Visibility="{Binding ViewModel.IsReadOnly, Converter={StaticResource NegatedBooleanToVisibilityConverter}, Mode=OneWay}"

--- a/PassKeep.App/Views/EntryDetailsView.xaml
+++ b/PassKeep.App/Views/EntryDetailsView.xaml
@@ -276,7 +276,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
         </RelativePanel>
     </ScrollViewer>
 
-    <view:EntryDetailsViewBase.BottomAppBar>
+    <view:EntryDetailsViewBase.CommandBar>
         <CommandBar DataContext="{x:Bind}">
             <CommandBar.PrimaryCommands>
                 <AppBarButton Icon="Delete" x:Uid="DeleteField"
@@ -301,5 +301,5 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                                     Unchecked="editToggleButton_Unchecked" />
             </CommandBar.PrimaryCommands>
         </CommandBar>
-    </view:EntryDetailsViewBase.BottomAppBar>
+    </view:EntryDetailsViewBase.CommandBar>
 </view:EntryDetailsViewBase>

--- a/PassKeep.App/Views/GroupDetailsView.xaml
+++ b/PassKeep.App/Views/GroupDetailsView.xaml
@@ -62,7 +62,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
     </ScrollViewer>
 
     <view:GroupDetailsViewBase.CommandBar>
-        <CommandBar>
+        <CommandBar DefaultLabelPosition="Right">
             <CommandBar.PrimaryCommands>
                 <AppBarButton Icon="Save" x:Uid="DetailsSave" Click="SaveButtonClick"
                               Visibility="{Binding IsReadOnly, Converter={StaticResource NegatedBooleanToVisibilityConverter}}" />

--- a/PassKeep.App/Views/GroupDetailsView.xaml
+++ b/PassKeep.App/Views/GroupDetailsView.xaml
@@ -61,7 +61,7 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
         </RelativePanel>
     </ScrollViewer>
 
-    <view:GroupDetailsViewBase.BottomAppBar>
+    <view:GroupDetailsViewBase.CommandBar>
         <CommandBar>
             <CommandBar.PrimaryCommands>
                 <AppBarButton Icon="Save" x:Uid="DetailsSave" Click="SaveButtonClick"
@@ -73,5 +73,5 @@ For the full license, see gpl-3.0.md in this solution or under https://bitbucket
                                     Unchecked="editToggleButton_Unchecked" />
             </CommandBar.PrimaryCommands>
         </CommandBar>
-    </view:GroupDetailsViewBase.BottomAppBar>
+    </view:GroupDetailsViewBase.CommandBar>
 </view:GroupDetailsViewBase>

--- a/PassKeep.Lib/Contracts/Providers/IDatabaseNodeViewModelFactory.cs
+++ b/PassKeep.Lib/Contracts/Providers/IDatabaseNodeViewModelFactory.cs
@@ -1,0 +1,10 @@
+﻿using PassKeep.Lib.Contracts.Models;
+using PassKeep.Lib.Contracts.ViewModels;
+
+namespace PassKeep.Lib.Contracts.Providers
+{
+    public interface IDatabaseNodeViewModelFactory
+    {
+        IDatabaseNodeViewModel Assemble(IKeePassNode node);
+    }
+}

--- a/PassKeep.Lib/Contracts/Providers/IDatabasePersistenceServiceFactory.cs
+++ b/PassKeep.Lib/Contracts/Providers/IDatabasePersistenceServiceFactory.cs
@@ -1,0 +1,22 @@
+﻿using PassKeep.Contracts.Models;
+using PassKeep.Lib.Contracts.KeePass;
+using PassKeep.Lib.Contracts.Services;
+
+namespace PassKeep.Lib.Contracts.Providers
+{
+    /// <summary>
+    /// Generates services capable of saving databases.
+    /// </summary>
+    public interface IDatabasePersistenceServiceFactory
+    {
+        /// <summary>
+        /// Assembles a service that can save a database.
+        /// </summary>
+        /// <param name="writer">Serializes databases.</param>
+        /// <param name="settings">Describes how to serialize databases.</param>
+        /// <param name="candidate">What to serialize.</param>
+        /// <param name="canSave">Whether saving is possible.</param>
+        /// <returns></returns>
+        IDatabasePersistenceService Assemble(IKdbxWriter writer, IDatabaseSettingsProvider settings, IDatabaseCandidate candidate, bool canSave);
+    }
+}

--- a/PassKeep.Lib/Contracts/Providers/IDatabasePersistenceStatusProvider.cs
+++ b/PassKeep.Lib/Contracts/Providers/IDatabasePersistenceStatusProvider.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+
+namespace PassKeep.Lib.Contracts.Providers
+{
+    /// <summary>
+    /// Allows the app to monitor whether a save is in progress.
+    /// </summary>
+    public interface IDatabasePersistenceStatusProvider : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Whether a save is in progress.
+        /// </summary>
+        bool IsSaving { get; }
+    }
+}

--- a/PassKeep.Lib/Contracts/Services/IDatabasePersistenceService.cs
+++ b/PassKeep.Lib/Contracts/Services/IDatabasePersistenceService.cs
@@ -5,9 +5,7 @@
 using PassKeep.Lib.Contracts.Providers;
 using PassKeep.Lib.KeePass.Dom;
 using System.ComponentModel;
-using System.Threading;
 using System.Threading.Tasks;
-using Windows.Storage;
 
 namespace PassKeep.Lib.Contracts.Services
 {
@@ -17,14 +15,14 @@ namespace PassKeep.Lib.Contracts.Services
     public interface IDatabasePersistenceService : INotifyPropertyChanged
     {
         /// <summary>
-        /// Whether the service is currently capable of persisting a document.
-        /// </summary>
-        bool CanSave { get; }
-
-        /// <summary>
         /// Whether a save operation is currently in progress.
         /// </summary>
         bool IsSaving { get; }
+
+        /// <summary>
+        /// Whether the service is currently capable of persisting a document.
+        /// </summary>
+        bool CanSave { get; }
 
         /// <summary>
         /// The database settings provider used to inform how the database gets persisted.

--- a/PassKeep.Lib/Contracts/ViewModels/IDatabaseGroupViewModel.cs
+++ b/PassKeep.Lib/Contracts/ViewModels/IDatabaseGroupViewModel.cs
@@ -2,6 +2,8 @@
 // This file is part of PassKeep and is licensed under the GNU GPL v3.
 // For the full license, see gpl-3.0.md in this solution or under https://bitbucket.org/sapph/passkeep/src
 
+using PassKeep.Lib.Contracts.Models;
+using SariphLib.Mvvm;
 using System;
 using System.Windows.Input;
 
@@ -22,5 +24,15 @@ namespace PassKeep.Lib.Contracts.ViewModels
         /// Command for requesting to open the current group.
         /// </summary>
         ICommand RequestOpenCommand { get; }
+
+        /// <summary>
+        /// Allows binding to a continually sorted list of nodes in the current document view.
+        /// </summary>
+        ReadOnlyObservableCollectionTransform<IKeePassNode, IDatabaseNodeViewModel> Children { get; }
+
+        /// <summary>
+        /// Whether this node has any children to bind to.
+        /// </summary>
+        bool HasChildren { get; }
     }
 }

--- a/PassKeep.Lib/Contracts/ViewModels/IDatabaseNavigationViewModel.cs
+++ b/PassKeep.Lib/Contracts/ViewModels/IDatabaseNavigationViewModel.cs
@@ -25,6 +25,12 @@ namespace PassKeep.Lib.Contracts.ViewModels
             get;
         }
 
+        // TODO: Implement this for TreeView support
+        /// <summary>
+        /// Allows binding to a continually sorted list of nodes in the current document view.
+        /// </summary>
+        // ReadOnlyObservableCollection<IDatabaseNodeViewModel> SortedChildren { get; }
+
         /// <summary>
         /// The last group in the breadcrumb trail - the group the user is currently exploring.
         /// </summary>

--- a/PassKeep.Lib/Contracts/ViewModels/IDatabaseViewModel.cs
+++ b/PassKeep.Lib/Contracts/ViewModels/IDatabaseViewModel.cs
@@ -6,6 +6,7 @@ using PassKeep.Lib.Contracts.Enums;
 using PassKeep.Lib.Contracts.Models;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 using Windows.Foundation;
 
@@ -63,6 +64,8 @@ namespace PassKeep.Lib.Contracts.ViewModels
             set;
         }
 
+        IDatabaseGroupViewModel RootGroup { get; }
+
         /// <summary>
         /// Allows binding to a continually sorted list of nodes in the current document view.
         /// </summary>
@@ -116,5 +119,13 @@ namespace PassKeep.Lib.Contracts.ViewModels
         /// <param name="editing">Whether to open the group in edit mode.</param>
         /// <returns>A GroupDetailsViewModel for an existing group.</returns>
         IGroupDetailsViewModel GetGroupDetailsViewModel(IKeePassGroup group, bool editing);
+
+        /// <summary>
+        /// Enumerates the children of a specific group according to sort settings.
+        /// </summary>
+        /// <param name="root">The node to enumerate.</param>
+        /// <param name="searchQuery">Used for filtering.</param>
+        /// <returns>An ordered collection of the root's children.</returns>
+        IOrderedEnumerable<IDatabaseNodeViewModel> GenerateSortedChildren(IKeePassGroup root, string searchQuery);
     }
 }

--- a/PassKeep.Lib/Contracts/ViewModels/IRootViewModel.cs
+++ b/PassKeep.Lib/Contracts/ViewModels/IRootViewModel.cs
@@ -16,6 +16,14 @@ namespace PassKeep.Lib.Contracts.ViewModels
         /// </summary>
         event EventHandler ClipboardClearFailed;
 
+        /// <summary>
+        /// Whether the app is currenly saving a database.
+        /// </summary>
+        bool IsSaving
+        {
+            get;
+        }
+
         ActivationMode ActivationMode
         {
             get;

--- a/PassKeep.Lib/KeePass/Dom/KdbxBinary.cs
+++ b/PassKeep.Lib/KeePass/Dom/KdbxBinary.cs
@@ -200,8 +200,7 @@ namespace PassKeep.Lib.KeePass.Dom
         /// <returns></returns>
         public override bool Equals(object obj)
         {
-            KdbxBinary other = obj as KdbxBinary;
-            if (other == null)
+            if (!(obj is KdbxBinary other))
             {
                 return false;
             }

--- a/PassKeep.Lib/KeePass/Dom/KdbxRoot.cs
+++ b/PassKeep.Lib/KeePass/Dom/KdbxRoot.cs
@@ -53,8 +53,7 @@ namespace PassKeep.Lib.KeePass.Dom
 
         public override bool Equals(object obj)
         {
-            KdbxRoot other = obj as KdbxRoot;
-            if (other == null)
+            if (!(obj is KdbxRoot other))
             {
                 return false;
             }

--- a/PassKeep.Lib/KeePass/Helpers/KdbxUrlResolver.cs
+++ b/PassKeep.Lib/KeePass/Helpers/KdbxUrlResolver.cs
@@ -40,7 +40,7 @@ namespace PassKeep.Lib.KeePass.Helpers
         public static Uri GetLaunchableUri(this IKeePassEntry entry)
         {
             string uriCandidate = entry.ConstructUriString();
-            if (uriCandidate == null)
+            if (string.IsNullOrWhiteSpace(uriCandidate))
             {
                 return null;
             }

--- a/PassKeep.Lib/Models/NodeComparer.cs
+++ b/PassKeep.Lib/Models/NodeComparer.cs
@@ -1,0 +1,39 @@
+﻿using PassKeep.Lib.Contracts.Models;
+using System.Collections.Generic;
+
+namespace PassKeep.Lib.Models
+{
+    public static class NodeComparer
+    {
+        /// <summary>
+        /// A comparer that sorts groups before entries.
+        /// </summary>
+        public static readonly Comparer<IKeePassNode> GroupFirstComparer = Comparer<IKeePassNode>.Create(
+            (nodeX, nodeY) =>
+            {
+                if (nodeX is IKeePassGroup)
+                {
+                    if (nodeY is IKeePassGroup)
+                    {
+                        // Both are groups
+                        return 0;
+                    }
+
+                    // X is a group and Y is an entry
+                    return -1;
+                }
+                else
+                {
+                    if (nodeY is IKeePassGroup)
+                    {
+                        // X is an entry and Y is a group
+                        return 1;
+                    }
+
+                    // Both are entries
+                    return 0;
+                }
+            }
+        );
+    }
+}

--- a/PassKeep.Lib/PassKeep.Lib.csproj
+++ b/PassKeep.Lib/PassKeep.Lib.csproj
@@ -166,6 +166,9 @@
     <Compile Include="Contracts\Providers\ICryptoRngProvider.cs" />
     <Compile Include="Contracts\Providers\IDatabaseCandidateFactory.cs" />
     <Compile Include="Contracts\Providers\IDatabaseCredentialProviderFactory.cs" />
+    <Compile Include="Contracts\Providers\IDatabaseNodeViewModelFactory.cs" />
+    <Compile Include="Contracts\Providers\IDatabasePersistenceServiceFactory.cs" />
+    <Compile Include="Contracts\Providers\IDatabasePersistenceStatusProvider.cs" />
     <Compile Include="Contracts\Providers\IDatabaseSettingsProvider.cs" />
     <Compile Include="Contracts\Providers\IDatabaseSettingsViewModelFactory.cs" />
     <Compile Include="Contracts\Providers\IFileProxyProvider.cs" />
@@ -282,6 +285,7 @@
     <Compile Include="Models\DesignTime\MockEntry.cs" />
     <Compile Include="Models\DesignTime\MockGroup.cs" />
     <Compile Include="Models\MessageOfTheDay.cs" />
+    <Compile Include="Models\NodeComparer.cs" />
     <Compile Include="Models\PasswordRecipe.cs" />
     <Compile Include="Models\ProtectedBinary.cs" />
     <Compile Include="Models\StorageFileDatabaseCandidate.cs" />
@@ -291,6 +295,7 @@
     <Compile Include="Providers\DatabaseCredentialProvider.cs" />
     <Compile Include="Providers\DatabaseCredentialProviderFactory.cs" />
     <Compile Include="Providers\DatabaseSettingsViewModelFactory.cs" />
+    <Compile Include="Providers\DefaultFilePersistenceServiceFactory.cs" />
     <Compile Include="Providers\DispatcherTimerFactory.cs" />
     <Compile Include="Providers\FileProxyProvider.cs" />
     <Compile Include="Contracts\Providers\IDatabaseCredentialProvider.cs" />

--- a/PassKeep.Lib/Providers/DefaultFilePersistenceServiceFactory.cs
+++ b/PassKeep.Lib/Providers/DefaultFilePersistenceServiceFactory.cs
@@ -1,0 +1,67 @@
+﻿using PassKeep.Contracts.Models;
+using PassKeep.Lib.Contracts.KeePass;
+using PassKeep.Lib.Contracts.Providers;
+using PassKeep.Lib.Contracts.Services;
+using PassKeep.Lib.Services;
+using SariphLib.Mvvm;
+
+namespace PassKeep.Lib.Providers
+{
+    /// <summary>
+    /// Generates services that know how to save databases to a file.
+    /// </summary>
+    public class DefaultFilePersistenceServiceFactory : BindableBase, IDatabasePersistenceServiceFactory, IDatabasePersistenceStatusProvider
+    {
+        private readonly ISyncContext syncContext;
+
+        /// <summary>
+        /// Inits the factory.
+        /// </summary>
+        /// <param name="syncContext">Synchronizes access to the UI thread.</param>
+        public DefaultFilePersistenceServiceFactory(ISyncContext syncContext)
+        {
+            this.syncContext = syncContext;
+        }
+
+        public bool IsSaving
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Assembles a service.
+        /// </summary>
+        /// <param name="writer">Serializes.</param>
+        /// <param name="settings">How to serialize.</param>
+        /// <param name="candidate">What to serialize.</param>
+        /// <param name="canSave">Whether serialization is possible.</param>
+        /// <returns></returns>
+        public IDatabasePersistenceService Assemble(IKdbxWriter writer, IDatabaseSettingsProvider settings, IDatabaseCandidate candidate, bool canSave)
+        {
+            DefaultFilePersistenceService service = new DefaultFilePersistenceService(
+                writer,
+                settings,
+                candidate,
+                this.syncContext,
+                canSave
+            );
+
+            service.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(service.IsSaving))
+                {
+                    // TODO: Evaluate whether this needs to be debounced or aggregated
+                    bool was = IsSaving;
+                    IsSaving = service.IsSaving;
+                    if (was != IsSaving)
+                    {
+                        OnPropertyChanged(nameof(IsSaving));
+                    }
+                }
+            };
+
+            return service;
+        }
+    }
+}

--- a/PassKeep.Lib/ViewModels/DatabaseGroupViewModel.cs
+++ b/PassKeep.Lib/ViewModels/DatabaseGroupViewModel.cs
@@ -3,9 +3,13 @@
 // For the full license, see gpl-3.0.md in this solution or under https://bitbucket.org/sapph/passkeep/src
 
 using PassKeep.Lib.Contracts.Models;
+using PassKeep.Lib.Contracts.Providers;
 using PassKeep.Lib.Contracts.ViewModels;
 using SariphLib.Mvvm;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 
 namespace PassKeep.Lib.ViewModels
@@ -19,10 +23,12 @@ namespace PassKeep.Lib.ViewModels
         /// Initializes the ViewModel.
         /// </summary>
         /// <param name="group">The database group to proxy.</param>
+        /// <param name="childFactory">Used to map child nodes to new ViewModels.</param>
         /// <param name="isReadOnly">Whether the database is in a state that can be edited.</param>
-        public DatabaseGroupViewModel(IKeePassGroup group, bool isReadOnly)
+        public DatabaseGroupViewModel(IKeePassGroup group, IDatabaseNodeViewModelFactory childFactory, bool isReadOnly)
             : base(group, isReadOnly)
         {
+            Children = new ReadOnlyObservableCollectionTransform<IKeePassNode, IDatabaseNodeViewModel>(group.Children, childFactory.Assemble);
             RequestOpenCommand = new ActionCommand(FireOpenRequested);
         }
 
@@ -44,5 +50,14 @@ namespace PassKeep.Lib.ViewModels
             get;
             private set;
         }
+
+        public ReadOnlyObservableCollectionTransform<IKeePassNode, IDatabaseNodeViewModel> Children { get; }
+
+        /// <summary>
+        /// Whether this group has children.
+        /// </summary>
+        public bool HasChildren => Children.Any();
     }
+
+    public delegate IOrderedEnumerable<IDatabaseNodeViewModel> ChildBuilder(IKeePassGroup root);
 }

--- a/PassKeep.Lib/ViewModels/DatabaseNodeViewModel.cs
+++ b/PassKeep.Lib/ViewModels/DatabaseNodeViewModel.cs
@@ -16,8 +16,6 @@ namespace PassKeep.Lib.ViewModels
     /// </summary>
     public class DatabaseNodeViewModel : IDatabaseNodeViewModel
     {
-        private Func<bool> canEdit;
-
         /// <summary>
         /// Initializes the proxy.
         /// </summary>
@@ -27,12 +25,14 @@ namespace PassKeep.Lib.ViewModels
         {
             Node = node ?? throw new ArgumentNullException(nameof(node));
 
-            this.canEdit = () => !readOnly;
+            CanEdit = () => !readOnly;
 
-            RequestRenameCommand = new ActionCommand(this.canEdit, FireRenameRequested);
-            RequestEditDetailsCommand = new ActionCommand(this.canEdit, FireEditRequested);
-            RequestDeleteCommand = new ActionCommand(this.canEdit, FireDeleteRequested);
+            RequestRenameCommand = new ActionCommand(CanEdit, FireRenameRequested);
+            RequestEditDetailsCommand = new ActionCommand(CanEdit, FireEditRequested);
+            RequestDeleteCommand = new ActionCommand(CanEdit, FireDeleteRequested);
         }
+
+        protected Func<bool> CanEdit { get; }
 
         /// <summary>
         /// Fired when the user requests a rename of this node.

--- a/PassKeep.Lib/ViewModels/DesignTime/DesignDatabaseViewModel.cs
+++ b/PassKeep.Lib/ViewModels/DesignTime/DesignDatabaseViewModel.cs
@@ -89,6 +89,8 @@ namespace PassKeep.ViewModels.DesignTime
             set;
         }
 
+        public IDatabaseGroupViewModel RootGroup { get; set; }
+
         public IReadOnlyCollection<DatabaseSortMode> AvailableSortModes
         {
             get;
@@ -171,6 +173,11 @@ namespace PassKeep.ViewModels.DesignTime
         }
 
         public ICollection<IKeePassNode> GetAllSearchableNodes(string query)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IOrderedEnumerable<IDatabaseNodeViewModel> GenerateSortedChildren(IKeePassGroup root, string filter)
         {
             throw new NotImplementedException();
         }

--- a/PassKeep.Lib/ViewModels/NodeDetailsViewModel.cs
+++ b/PassKeep.Lib/ViewModels/NodeDetailsViewModel.cs
@@ -55,11 +55,6 @@ namespace PassKeep.Lib.ViewModels
                 throw new ArgumentException("Cannot create a new node with no parent!");
             }
 
-            if (navigationViewModel.ActiveGroup != item.Parent)
-            {
-                throw new ArgumentException("The database's active group must be the node's parent!");
-            }
-
             NavigationViewModel = navigationViewModel ?? throw new ArgumentNullException(nameof(navigationViewModel));
             Document = document ?? throw new ArgumentNullException(nameof(document));
             IsNew = isNew;

--- a/PassKeep.Tests/DatabaseUnlockViewModelTests.cs
+++ b/PassKeep.Tests/DatabaseUnlockViewModelTests.cs
@@ -118,7 +118,7 @@ namespace PassKeep.Tests
             );
             
             this.viewModel = new DatabaseUnlockViewModel(
-                new MockSyncContext(),
+                new DefaultFilePersistenceServiceFactory(new MockSyncContext()),
                 databaseValue,
                 sampleValue,
                 this.accessList,

--- a/PassKeep.Tests/Mocks/MockEventLogger.cs
+++ b/PassKeep.Tests/Mocks/MockEventLogger.cs
@@ -107,5 +107,10 @@ namespace PassKeep.Tests.Mocks
             IsTracing = false;
             return Task.FromResult<ITestableFile>(new MockStorageFile { Name = fileName });
         }
+
+        public void Trace(string caller, string context = "", EventVerbosity verbosity = EventVerbosity.Info, string method = "")
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/PassKeep.Tests/ReadOnlyStorageFileTests.cs
+++ b/PassKeep.Tests/ReadOnlyStorageFileTests.cs
@@ -39,7 +39,7 @@ namespace PassKeep.Tests
             TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
             ICredentialStorageProvider credentialStorage = new MockCredentialProvider();
             IDatabaseUnlockViewModel viewModel = new DatabaseUnlockViewModel(
-                new MockSyncContext(),
+                new DefaultFilePersistenceServiceFactory(new MockSyncContext()),
                 await factory.AssembleAsync(databaseInfo.Database),
                 false,
                 new MockStorageItemAccessList(),

--- a/SariphLib.Universal/Diagnostics/EtwTraceLogger.cs
+++ b/SariphLib.Universal/Diagnostics/EtwTraceLogger.cs
@@ -4,6 +4,8 @@
 
 using SariphLib.Files;
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Windows.Foundation.Diagnostics;
 using Windows.Storage;
@@ -65,6 +67,23 @@ namespace SariphLib.Diagnostics
             }
 
             this.logger.LogEvent(eventName, fields, GetLoggingLevel(verbosity));
+        }
+
+        /// <summary>
+        /// Logs an event with context about the calling function. Useful for perf diagnostics.
+        /// </summary>
+        /// <param name="caller">Identifier for the class doing the tracing.</param>
+        /// <param name="verbosity">Verbosity for the logged event.</param>
+        /// <param name="context">Context to include in the log.</param>
+        /// <param name="method">The method name to trace.</param>
+        public void Trace(string caller, string context = "", EventVerbosity verbosity = EventVerbosity.Info, [CallerMemberName] string method = "")
+        {
+            LoggingFields fields = new LoggingFields();
+            fields.AddString("Caller", caller);
+            fields.AddString("Method", method);
+            fields.AddString("Context", context);
+            LogEvent("Trace", fields, verbosity);
+            Debug.WriteLine($"{caller}.{method}: {context}");
         }
 
         /// <summary>

--- a/SariphLib.Universal/Diagnostics/IEventLogger.cs
+++ b/SariphLib.Universal/Diagnostics/IEventLogger.cs
@@ -26,6 +26,15 @@ namespace SariphLib.Diagnostics
         /// <param name="fields">Payload to associate with the event.</param>
         /// <param name="verbosity">The verbosity to log the event with.</param>
         void LogEvent(string eventName, LoggingFields fields, EventVerbosity verbosity);
+
+        /// <summary>
+        /// Logs an event with context about the calling function. Useful for perf diagnostics.
+        /// </summary>
+        /// <param name="caller">Identifier for the class doing the tracing.</param>
+        /// <param name="verbosity">Verbosity for the logged event.</param>
+        /// <param name="context">Context to include in the log.</param>
+        /// <param name="method">The method name to trace.</param>
+        void Trace(string caller, string context = "", EventVerbosity verbosity = EventVerbosity.Info, string method = "");
     }
 
     /// <summary>

--- a/SariphLib.Universal/Diagnostics/NullLogger.cs
+++ b/SariphLib.Universal/Diagnostics/NullLogger.cs
@@ -44,5 +44,17 @@ namespace SariphLib.Diagnostics
         {
             return;
         }
+
+        /// <summary>
+        /// No-op.
+        /// </summary>
+        /// <param name="caller"></param>
+        /// <param name="context"></param>
+        /// <param name="verbosity"></param>
+        /// <param name="method"></param>
+        public void Trace(string caller, string context, EventVerbosity verbosity, string method)
+        {
+            return;
+        }
     }
 }

--- a/SariphLib.Universal/Mvvm/FrameworkExtensions.cs
+++ b/SariphLib.Universal/Mvvm/FrameworkExtensions.cs
@@ -35,10 +35,10 @@ namespace SariphLib.Mvvm
             }
 
             // Iterate over children to recursively search
-            var childCount = VisualTreeHelper.GetChildrenCount(element);
+            int childCount = VisualTreeHelper.GetChildrenCount(element);
             for (int i = 0; i < childCount; i++)
             {
-                var result = (VisualTreeHelper.GetChild(element, i) as FrameworkElement).FindDescendantByName(name);
+                FrameworkElement result = (VisualTreeHelper.GetChild(element, i) as FrameworkElement).FindDescendantByName(name);
                 if (result != null)
                 {
                     return result;
@@ -68,7 +68,7 @@ namespace SariphLib.Mvvm
             }
 
             int childCount = VisualTreeHelper.GetChildrenCount(root);
-            for (var i = 0; i < childCount; i++)
+            for (int i = 0; i < childCount; i++)
             {
                 DependencyObject child = VisualTreeHelper.GetChild(root, i);
                 T firstChildOfType = child.FindDescendantByType<T>();

--- a/SariphLib.Universal/Mvvm/ReadOnlyObservableCollectionTransform.cs
+++ b/SariphLib.Universal/Mvvm/ReadOnlyObservableCollectionTransform.cs
@@ -1,0 +1,139 @@
+﻿using SariphLib.Eventing;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace SariphLib.Mvvm
+{
+    /// <summary>
+    /// A readonly observable collection that represents a transform/projection of an existing observable collection.
+    /// </summary>
+    /// <typeparam name="TSource">The type to project from.</typeparam>
+    /// <typeparam name="TProject">The type to project to.</typeparam>
+    public class ReadOnlyObservableCollectionTransform<TSource, TProject>: BindableBase, INotifyCollectionChanged, IReadOnlyCollection<TProject>
+    {
+        private List<TProject> projection;
+        private readonly Func<TSource, TProject> transformer;
+
+        /// <summary>
+        /// Initializes this collection from a source collection.
+        /// </summary>
+        /// <param name="source">The collection to wrap.</param>
+        /// <param name="transformer">A function that performs the projection/transformation.</param>
+        public ReadOnlyObservableCollectionTransform(ObservableCollection<TSource> source, Func<TSource, TProject> transformer)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            this.transformer = transformer ?? throw new ArgumentNullException(nameof(transformer));
+            source.CollectionChanged += new WeakEventHandler<NotifyCollectionChangedEventArgs>(HandleCollectionChanged).Handler;
+
+            BuildProjection(source);
+        }
+
+        /// <summary>
+        /// Invoked on behalf of the wrapped collection whenever it changes.
+        /// </summary>
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+        {
+            var source = (ObservableCollection<TSource>)sender;
+            switch (args.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    var added = new List<TProject>(args.NewItems.Count);
+                    for (int i = 0; i < args.NewItems.Count; i++)
+                    {
+                        added.Add(this.transformer((TSource)args.NewItems[i]));
+                    }
+
+                    this.projection.InsertRange(args.NewStartingIndex, added);
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(args.Action, added, args.NewStartingIndex));
+                    OnPropertyChanged(nameof(Count));
+
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    if (args.NewItems.Count > 1)
+                    {
+                        throw new NotImplementedException();
+                    }
+
+                    TProject item = this.projection[args.OldStartingIndex];
+                    this.projection.RemoveAt(args.OldStartingIndex);
+                    this.projection.Insert(args.NewStartingIndex, item);
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(args.Action, item, args.OldStartingIndex, args.NewStartingIndex));
+
+                    break;
+                case NotifyCollectionChangedAction.Remove:
+                    var removed = new List<TProject>(args.OldItems.Count);
+                    for (int i = 0; i < args.OldItems.Count; i++)
+                    {
+                        removed.Add(this.projection[i + args.OldStartingIndex]);
+                    }
+
+                    this.projection.RemoveRange(args.OldStartingIndex, args.OldItems.Count);
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(args.Action, removed, args.OldStartingIndex));
+                    OnPropertyChanged(nameof(Count));
+
+                    break;
+                case NotifyCollectionChangedAction.Replace:
+                    if (args.NewItems.Count != args.OldItems.Count || args.NewStartingIndex != args.OldStartingIndex)
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var newItems = new List<TProject>(args.NewItems.Count);
+                    var replaced = new List<TProject>(args.NewItems.Count);
+
+                    for (int i = 0; i < args.NewItems.Count; i++)
+                    {
+                        TProject newItem = this.transformer((TSource)args.NewItems[i]);
+                        replaced.Add(this.projection[i + args.NewStartingIndex]);
+                        newItems.Add(newItem);
+                        this.projection[i + args.NewStartingIndex] = newItem;
+                    }
+
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(args.Action, newItems, replaced, args.NewStartingIndex));
+
+                    break;
+                case NotifyCollectionChangedAction.Reset:
+                    BuildProjection(source);
+                    break;
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+        private void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
+            CollectionChanged?.Invoke(this, e);
+        }
+
+        private void BuildProjection(ObservableCollection<TSource> source)
+        {
+            this.projection = new List<TProject>(source.Count);
+            foreach (TSource sourceEle in source)
+            {
+                this.projection.Add(this.transformer(sourceEle));
+            }
+
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            OnPropertyChanged(nameof(Count));
+        }
+
+        #region IReadOnlyCollection
+
+        public int Count => this.projection.Count;
+
+        public IEnumerator<TProject> GetEnumerator() => this.projection.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        #endregion
+    }
+}

--- a/SariphLib.Universal/SariphLib.Universal.csproj
+++ b/SariphLib.Universal/SariphLib.Universal.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Mvvm\ITimer.cs" />
     <Compile Include="Mvvm\NotifyTaskCompletionGeneric.cs" />
     <Compile Include="Mvvm\NotifyTaskCompletion.cs" />
+    <Compile Include="Mvvm\ReadOnlyObservableCollectionTransform.cs" />
     <Compile Include="Mvvm\TypedCommand.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Testing\MockFolderPickerService.cs" />


### PR DESCRIPTION
This is a bunch of work I'd started in 2018 to clean up some of the legacy Windows 8 APIs I was still using.

* Replace 'BottomAppBar' with the newer CommandBar
* Remove SettingsPane/SettingsFlyout
* Add a TreeView to the main database view (work in progress)